### PR TITLE
Add plan mode, bump Terraform/Terragrunt to 1.9.8/1.1.0

### DIFF
--- a/.github/workflows/terragrunt.yaml
+++ b/.github/workflows/terragrunt.yaml
@@ -21,17 +21,22 @@ on:
       tg-version:
         required: false
         type: string
-        default: 0.48.5
-          
+        default: 1.1.0
+
       tg-destroy:
         required: false
         type: boolean
         default: false
-            
+
+      tg-plan:
+        required: false
+        type: boolean
+        default: false
+
       tf-version:
         required: false
         type: string
-        default: latest
+        default: 1.9.8
             
       infra-dir:
         required: false
@@ -73,7 +78,7 @@ on:
 
 jobs:
   Deploy-infra:
-    if: ${{ (github.event.pull_request.merged == true || github.event_name == 'push') && needs.pre-check.outputs.should_skip != 'true' }}
+    if: ${{ (inputs.tg-plan == true || github.event.pull_request.merged == true || github.event_name == 'push') && needs.pre-check.outputs.should_skip != 'true' }}
     name: 'Deploy Infra'
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
@@ -145,8 +150,14 @@ jobs:
     - name: Install Just
       uses: extractions/setup-just@v1
 
+    - name: Terragrunt Plan
+      if: ${{ (inputs.tg-plan == true) }}
+      continue-on-error: false
+      run: |
+        just infraDir=${{ inputs.infra-dir }} plan-all
+
     - name: Terragrunt Apply
-      if: ${{ (inputs.tg-destroy == false) }}
+      if: ${{ (inputs.tg-plan == false) && (inputs.tg-destroy == false) }}
       continue-on-error: false
       run: |
         just infraDir=${{ inputs.infra-dir }} apply-all
@@ -157,9 +168,9 @@ jobs:
     #   with:
     #     limit-access-to-actor: true
     #     limit-access-to-users: Fomiller
-             
+
     - name: Terragrunt Destroy
-      if: ${{ (inputs.tg-destroy == true) }}
+      if: ${{ (inputs.tg-plan == false) && (inputs.tg-destroy == true) }}
       continue-on-error: false
       run: |
         just infraDir=${{ inputs.infra-dir }} destroy-all


### PR DESCRIPTION
## Summary
- Adds a `tg-plan` input to the reusable `terragrunt.yaml` workflow — runs `just plan-all` instead of apply/destroy, and the job now also runs on non-merged PRs when `tg-plan: true` (not just push/merge).
- Bumps defaults: `tf-version` `latest` -> `1.9.8`, `tg-version` `0.48.5` -> `1.1.0`, matching what's installed locally.
- Backward compatible: existing callers not passing `tg-plan` behave exactly as before (apply/destroy unchanged), aside from picking up the new version defaults.

Driven by homelab's move to Terragrunt Stacks (see Fomiller/homelab#17), which needs a plan-on-PR / apply-on-merge split instead of always-apply.

## Test plan
- [ ] Confirm no other caller of `terragrunt.yaml` breaks on the new tf/tg version defaults.
- [x] Exercised via homelab's draft PR referencing this branch directly (`@homelab-terragrunt-stacks-plan-apply`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)